### PR TITLE
feat: add claudecode.nvim and terminal buffer integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,29 @@ require("git-wt").setup({
     --   vim.cmd("Neotree dir=" .. dir)
     -- end,
   },
+
+  -- Built-in integrations (default: all enabled)
+  integrations = {
+    -- Restart claudecode.nvim session in the new worktree directory (default: true)
+    claudecode = true,
+
+    -- Send `cd <dir>` to all open terminal buffers (default: true)
+    terminal_cd = true,
+  },
 })
 ```
+
+### Integrations
+
+#### claudecode.nvim
+
+When [claudecode.nvim](https://github.com/anthropics/claude-code/tree/main/packages/neovim) is installed and its server is running, the plugin automatically restarts the Claude Code session after switching worktrees so that Claude picks up the new working directory.
+
+If claudecode.nvim is not installed, this integration is silently skipped.
+
+#### Terminal buffers
+
+After switching worktrees, the plugin sends `cd <dir>` to every open Neovim terminal buffer (`:terminal`) so that shell sessions stay in sync with the new working directory.
 
 ## How It Works
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -79,8 +79,29 @@ require("git-wt").setup({
     --   vim.cmd("Neotree dir=" .. dir)
     -- end,
   },
+
+  -- 組み込み連携機能（デフォルト: すべて有効）
+  integrations = {
+    -- ワークツリー切り替え時に claudecode.nvim のセッションを再起動（デフォルト: true）
+    claudecode = true,
+
+    -- 開いているターミナルバッファに `cd <dir>` を送信（デフォルト: true）
+    terminal_cd = true,
+  },
 })
 ```
+
+### 連携機能
+
+#### claudecode.nvim
+
+[claudecode.nvim](https://github.com/anthropics/claude-code/tree/main/packages/neovim) がインストールされていてサーバーが起動中の場合、ワークツリー切り替え後に Claude Code セッションを自動的に再起動し、新しい作業ディレクトリを反映します。
+
+claudecode.nvim がインストールされていない場合、この連携はスキップされます。
+
+#### ターミナルバッファ
+
+ワークツリー切り替え後、開いているすべての Neovim ターミナルバッファ（`:terminal`）に `cd <dir>` を送信し、シェルセッションのディレクトリも新しいワークツリーに同期します。
 
 ## 仕組み
 

--- a/lua/git-wt/init.lua
+++ b/lua/git-wt/init.lua
@@ -7,6 +7,13 @@ M.config = {
   notify = true,
   -- Hooks to run after cd (e.g., refresh neo-tree)
   hooks = {},
+  -- Built-in integrations
+  integrations = {
+    -- Restart claudecode.nvim session in the new worktree directory
+    claudecode = true,
+    -- Send `cd <dir>` to all open terminal buffers
+    terminal_cd = true,
+  },
 }
 
 function M.setup(opts)
@@ -67,6 +74,34 @@ function M.list(cb)
   end)
 end
 
+--- Restart claudecode.nvim session so it picks up the new cwd
+---@param dir string
+local function restart_claudecode(dir)
+  local ok, claudecode = pcall(require, "claudecode")
+  if not ok then
+    return
+  end
+  -- Only restart if the server is already running
+  if not (claudecode.state and claudecode.state.server) then
+    return
+  end
+  claudecode.stop()
+  claudecode.start(false)
+end
+
+--- Send `cd <dir>` to every open terminal buffer
+---@param dir string
+local function cd_terminal_buffers(dir)
+  for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+    if vim.api.nvim_buf_is_loaded(buf) and vim.bo[buf].buftype == "terminal" then
+      local chan = vim.bo[buf].channel
+      if chan and chan > 0 then
+        vim.api.nvim_chan_send(chan, "cd " .. vim.fn.shellescape(dir) .. "\n")
+      end
+    end
+  end
+end
+
 --- Change Neovim's cwd and trigger events so neo-tree etc. follow along
 ---@param dir string
 function M.cd(dir)
@@ -75,6 +110,14 @@ function M.cd(dir)
 
   if M.config.notify then
     vim.notify("git-wt: switched to " .. dir)
+  end
+
+  -- Built-in integrations
+  if M.config.integrations.claudecode then
+    restart_claudecode(dir)
+  end
+  if M.config.integrations.terminal_cd then
+    cd_terminal_buffers(dir)
   end
 
   -- Run user-defined hooks


### PR DESCRIPTION
## Summary

- `:GitWt` によるワークツリー切り替え時に **claudecode.nvim** のセッションを自動再起動し、新しい作業ディレクトリで Claude Code が動作するようにする
- `:GitWt` 実行時に開いている **ターミナルバッファ** に `cd <dir>` を送信し、シェルのディレクトリも同期する
- 両機能ともデフォルト有効、`integrations` オプションで個別に無効化可能
- README (en/ja) にドキュメント追加

Closes #1
Closes #2

## Test plan

- [ ] claudecode.nvim 起動中に `:GitWt` で切り替え → Claude Code セッションが新ディレクトリで再起動されること
- [ ] claudecode.nvim 未インストール環境で `:GitWt` → エラーなく動作すること
- [ ] ターミナルバッファを開いた状態で `:GitWt` → ターミナルの cwd が切り替わること
- [ ] ターミナルバッファなしで `:GitWt` → エラーなく動作すること
- [ ] `integrations = { claudecode = false, terminal_cd = false }` で無効化できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)