### PR TITLE
ci: add auto-release workflow on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create Release
+        run: gh release create "${{ github.ref_name }}" --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- タグ (`v*`) プッシュ時に GitHub Release を自動作成する GitHub Actions ワークフローを追加
- `--generate-notes` で自動的にリリースノートを生成

## Test plan

- [ ] `v*` パターンのタグをプッシュして、GitHub Release が自動作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)